### PR TITLE
Unsupported use case for `anyOf`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "alexanderallen/panettone",
-    "version": "0.0.1",
     "type": "library",
     "description": "A lightweight PHP type generator for Open API (formerly Swagger)",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,13 @@
         "symfony/console": "^6.0",
         "api-platform/schema-generator": "^5.2.2",
         "loophp/collection": "^7.5",
-        "nikic/iter": "^2.4"
+        "nikic/iter": "^2.4",
+        "cebe/php-openapi": "^1.7",
+        "nette/php-generator":"^4.1"
     },
     "require-dev": {
         "myclabs/php-enum": "^1.8",
-        "cebe/php-openapi": "^1.7",
         "nette/neon":"^3.4",
-        "nette/php-generator":"^4.1",
         "squizlabs/php_codesniffer": "^3.9",
         "phpunit/phpunit": "^10.0",
         "slevomat/coding-standard": "^8.15",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "alexanderallen/panettone",
+    "version": "0.0.1",
     "type": "library",
     "description": "A lightweight PHP type generator for Open API (formerly Swagger)",
     "keywords": [
@@ -12,7 +13,7 @@
         "swagger"
     ],
     "homepage": "https://github.com/AlexanderAllen/panettone",
-    "license": "MIT",
+    "license": "GPL-3.0-or-later",
     "authors": [
         {
             "name": "Richard Allen",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8443f29ee3c92a04068df85e4aef7db6",
+    "content-hash": "16e1b930e912b8574b4de50f038caa32",
     "packages": [
         {
             "name": "api-platform/schema-generator",

--- a/src/UnsupportedSchema.php
+++ b/src/UnsupportedSchema.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexanderAllen\Panettone;
+
+use cebe\openapi\spec\Schema;
+
+/**
+ * Unsupported Open API schema use case.
+ *
+ * @package Panettone
+ */
+final class UnsupportedSchema extends \UnexpectedValueException
+{
+    /**
+     * @param Schema $schema
+     *   The unsupported schema instance.
+     * @param string|null $name
+     *   Schema items can sometimes be anonymous, this parameter allows you identify them.
+     * @param string|null $error
+     *   The reason why this schema is not supported.
+     */
+    public function __construct(Schema $schema, string $name = null, string $error = null)
+    {
+        $_error = ($name !== null) ? sprintf('[%s] ', $name) : '';
+        $_error .= 'Unsupported use case';
+        $_error .= ($error !== null) ? sprintf(': %s', $error) : '.';
+        $_error .= PHP_EOL;
+        $_error .= sprintf('Schema path %s', $schema->getDocumentPosition()->getPointer());
+
+        parent::__construct($error, 1);
+    }
+}

--- a/tests/Unit/MedianocheTest.php
+++ b/tests/Unit/MedianocheTest.php
@@ -383,6 +383,13 @@ class MedianocheTest extends TestCase
             Collection::fromIterable($schema->items->getDocumentPosition()->getPath())
             ->last('');
 
+        $last = static fn (Schema $p, ?bool $list = false): string =>
+            Collection::fromIterable(
+                $list === false ?
+                $p->getDocumentPosition()->getPath() :
+                $p->items->getDocumentPosition()->getPath()
+            )->last('');
+
         // Native type parsing.
         $natives = static fn ($p) => ! in_array($p->type, ['object', 'array'], true);
 
@@ -409,9 +416,9 @@ class MedianocheTest extends TestCase
             $class->addMember($prop);
         }
 
-        $compositeGenerator = function ($array) use ($class_name): Generator {
+        $compositeGenerator = function ($array) use ($class_name, $last): Generator {
             foreach ($array as $key => $property) {
-                $lastRef = last($property);
+                $lastRef = $last($property);
 
                 // Pointer path with string ending is a reference to another schema.
                 if (! is_numeric($lastRef)) {
@@ -502,9 +509,4 @@ class MedianocheTest extends TestCase
                 }
             );
     }
-}
-
-function last(Schema $p): string
-{
-    return Collection::fromIterable($p->getDocumentPosition()->getPath())->last('');
 }

--- a/tests/Unit/MedianocheTest.php
+++ b/tests/Unit/MedianocheTest.php
@@ -270,7 +270,7 @@ class MedianocheTest extends TestCase
         $logger = new ConsoleLogger(new ConsoleOutput(ConsoleOutput::VERBOSITY_DEBUG));
         self::setLogger($logger);
         $spec = Reader::readFromYamlFile(
-            realpath('tests/fixtures/anyOf-simple.yml'),
+            realpath('tests/fixtures/starOf-simple.yml'),
             OpenAPI::class,
             ReferenceContext::RESOLVE_MODE_ALL,
         );

--- a/tests/Unit/MedianocheTest.php
+++ b/tests/Unit/MedianocheTest.php
@@ -379,10 +379,6 @@ class MedianocheTest extends TestCase
                 ->addUse('UseThisUseStmt', 'asAlias')
         );
 
-        $refdSchema = static fn (Schema $schema): string =>
-            Collection::fromIterable($schema->items->getDocumentPosition()->getPath())
-            ->last('');
-
         $last = static fn (Schema $p, ?bool $list = false): string =>
             Collection::fromIterable(
                 $list === false ?
@@ -412,7 +408,7 @@ class MedianocheTest extends TestCase
         if ($schema->type === 'array') {
             // Don't flatten or inline the reference, instead reference the schema as a type.
             $this->logger->debug(sprintf('[%s/%s] Add array class property', $class_name, 'items'));
-            $prop = $this->nativeProp($schema, 'items', null, $refdSchema($schema), $class_name);
+            $prop = $this->nativeProp($schema, 'items', null, $last($schema), $class_name);
             $class->addMember($prop);
         }
 

--- a/tests/Unit/MedianocheTest.php
+++ b/tests/Unit/MedianocheTest.php
@@ -270,7 +270,7 @@ class MedianocheTest extends TestCase
         $logger = new ConsoleLogger(new ConsoleOutput(ConsoleOutput::VERBOSITY_DEBUG));
         self::setLogger($logger);
         $spec = Reader::readFromYamlFile(
-            realpath('tests/fixtures/allOf-simple.yml'),
+            realpath('tests/fixtures/anyOf-simple.yml'),
             OpenAPI::class,
             ReferenceContext::RESOLVE_MODE_ALL,
         );

--- a/tests/Unit/MedianocheTest.php
+++ b/tests/Unit/MedianocheTest.php
@@ -157,8 +157,6 @@ class MedianocheTest extends TestCase
         );
         $printer = new Printer();
 
-        $callback = fn ($k = null, $v = null) => $this->logger->debug(sprintf('%s: ima call u back, %s', $k, $v));
-
         $classes = [];
         $expected_count = count($spec->components->schemas);
         foreach ($spec->components->schemas as $name => $schema) {
@@ -341,7 +339,7 @@ class MedianocheTest extends TestCase
         return $schemaType;
     }
 
-    public function newNetteClass(Schema $schema, string $class_name, callable $callback = null): ClassType
+    public function newNetteClass(Schema $schema, string $class_name): ClassType
     {
         $schemaType = $this->typeMatcher2000($schema, $class_name);
 

--- a/tests/fixtures/anyOf-invalid.yml
+++ b/tests/fixtures/anyOf-invalid.yml
@@ -1,0 +1,69 @@
+openapi: 3.0.1
+info:
+  title: Panettone starOf schemas
+  version: 1.0.0
+  description: |
+    Use case for unsupported `anyOf` schema.
+
+servers:
+  - url: https://localhost
+paths:
+  /me:
+    get:
+      summary: Boilerplate example response.
+      responses:
+        '200':
+          $ref: '#/components/responses/Panettone'
+
+components:
+
+  responses:
+    Panettone:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UnsupportedAnyOf'
+
+  schemas:
+    UnsupportedAnyOf:
+      anyOf:
+        - $ref: '#/components/schemas/Category'
+        - $ref: '#/components/schemas/Address'
+        # Anonymous inline object with no name, only props.
+        # this turns inline_obj_string into a property of UnsupportedAnyOf.
+        - type: object
+          properties:
+            inline_obj_string_prop_anyOf:
+              type: string
+
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+      xml:
+        name: category
+
+    Address:
+      type: object
+      properties:
+        street:
+          type: string
+          example: 437 Lytton
+        city:
+          type: string
+          example: Palo Alto
+        state:
+          type: string
+          example: CA
+        zip:
+          type: string
+          example: '94301'
+      xml:
+        name: address

--- a/tests/fixtures/anyOf-simple.yml
+++ b/tests/fixtures/anyOf-simple.yml
@@ -27,27 +27,6 @@ components:
             $ref: '#/components/schemas/PanettoneAnyOf'
 
   schemas:
-    # This is saying the contents of the reponse could have any of these types
-    # this is a OR operation
-    #
-    # PHP Type would look like
-    # public Me|Activities|string $inline_obj_string_prop_anyOf
-    #
-    # If I were to type this I would end up with an unpredictable result for the uer.
-    # So you know, just don't support this particular use of anyOf, it doesn't make sense.
-    #
-    # There should be a test that rejects this use case with an exception.
-    UnsupportedAnyOf:
-      anyOf:
-        # Types have a name, but there isn't a named property they're tied to.
-        - $ref: '#/components/schemas/Me'
-        - $ref: '#/components/schemas/Activities'
-        # Anonymous inline object with no name, only props.
-        # this turns inline_obj_string into a property of UnsupportedAnyOf.
-        - type: object
-          properties:
-            inline_obj_string_prop_anyOf:
-              type: string
 
     PanettoneAnyOf:
       type: object

--- a/tests/fixtures/anyOf-simple.yml
+++ b/tests/fixtures/anyOf-simple.yml
@@ -1,0 +1,124 @@
+openapi: 3.0.1
+info:
+  title: Panettone starOf schemas
+  version: 1.0.1
+  description: |
+    Simple use cases for `oneOf`, `anyOf`, `allOf`, and `not` schema types.
+
+
+servers:
+  - url: https://localhost
+paths:
+  /me:
+    get:
+      summary: Boilerplate example response.
+      responses:
+        '200':
+          $ref: '#/components/responses/Panettone'
+
+components:
+
+  responses:
+    Panettone:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PanettoneAnyOf'
+
+  schemas:
+    # This is saying the contents of the reponse could have any of these types
+    # this is a OR operation
+    #
+    # PHP Type would look like
+    # public Me|Activities|string $inline_obj_string_prop_anyOf
+    #
+    # If I were to type this I would end up with an unpredictable result for the uer.
+    # So you know, just don't support this particular use of anyOf, it doesn't make sense.
+    #
+    # There should be a test that rejects this use case with an exception.
+    UnsupportedAnyOf:
+      anyOf:
+        # Types have a name, but there isn't a named property they're tied to.
+        - $ref: '#/components/schemas/Me'
+        - $ref: '#/components/schemas/Activities'
+        # Anonymous inline object with no name, only props.
+        # this turns inline_obj_string into a property of UnsupportedAnyOf.
+        - type: object
+          properties:
+            inline_obj_string_prop_anyOf:
+              type: string
+
+    PanettoneAnyOf:
+      type: object
+      properties:
+        type:
+          description: Type of activity (track).
+          type: string
+        created_at:
+          description: Created timestamp.
+          type: string
+        origin:
+          description: Origin.
+          type: object
+          anyOf:
+            - $ref: '#/components/schemas/Me'
+            - $ref: '#/components/schemas/User'
+
+    Me:
+      type: object
+      description: SoundCloud Me object
+      properties:
+        avatar_url:
+          description: URL to a JPEG image.
+          type: string
+        city:
+          description: city.
+          type: string
+        comments_count:
+          description: comments count. From now on, the field always has a `0` value.
+          type: integer
+          deprecated: true
+
+    Activities:
+      type: object
+      description: User's activities.
+      properties:
+        collection:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                description: Type of activity (track).
+                type: string
+              created_at:
+                description: Created timestamp.
+                type: string
+              origin:
+                description: Origin.
+                type: object
+                anyOf:
+                  - $ref: '#/components/schemas/Me'
+                  - $ref: '#/components/schemas/User'
+        next_href:
+          type: string
+        future_href:
+          type: string
+
+    User:
+      type: object
+      description: SoundCloud User object
+      properties:
+        avatar_url:
+          description: URL to a JPEG image
+          type: string
+        username:
+          description: username
+          type: string
+        website:
+          description: a URL to the website
+          type: string
+        website_title:
+          description: a custom title for the website
+          type: string

--- a/tests/fixtures/anyOf-simple.yml
+++ b/tests/fixtures/anyOf-simple.yml
@@ -88,88 +88,6 @@ components:
         title:
           description: Track title.
           type: string
-        artwork_url:
-          description: URL to a JPEG image.
-          type: string
-        bpm:
-          description: Tempo.
-          type: integer
-        comment_count:
-          description: Number of comments.
-          type: integer
-        commentable:
-          description: Is commentable.
-          type: boolean
-        created_at:
-          description: Created timestamp.
-          type: string
-        description:
-          description: Track description.
-          type: string
-        download_count:
-          description: NUmber of downloads.
-          type: integer
-        downloadable:
-          description: Is downloadable.
-          type: string
-        duration:
-          description: Track duration.
-          type: integer
-        embeddable_by:
-          deprecated: true
-          description: Embeddable by.
-          type: string
-        favoritings_count:
-          description: Number of favoritings.
-          type: integer
-        genre:
-          description: Genre
-          type: string
-        id:
-          description: Track identifier.
-          type: integer
-        isrc:
-          description: ISRC code.
-          type: string
-        key_signature:
-          description: Key signature.
-          type: string
-        kind:
-          description: Type of object (track).
-          type: string
-        label_name:
-          description: Label user name.
-          type: string
-        license:
-          description: License
-          type: string
-        permalink_url:
-          description: Permalink URL.
-          type: string
-        playback_count:
-          description: Number of plays.
-          type: integer
-        purchase_title:
-          description: Purchase title.
-          type: string
-        purchase_url:
-          description: Purchase URL.
-          type: string
-        release:
-          description: Release.
-          type: string
-        release_day:
-          description: Day of release.
-          type: integer
-        release_month:
-          description: Month of release.
-          type: integer
-        release_year:
-          description: Year of release.
-          type: integer
-        sharing:
-          description: Type of sharing (public/private).
-          type: string
         stream_url:
           description: URL to stream.
           type: string
@@ -182,18 +100,11 @@ components:
         uri:
           description: Track URI.
           type: string
-        # Having trouble with references in Panettone 3/8/2024.
-        # user:
-        #   $ref: '#/components/schemas/User'
+        user:
+          $ref: '#/components/schemas/User'
         user_favorite:
           description: Is user's favourite.
           type: boolean
-        user_playback_count:
-          description: Number of plays by a user.
-          type: integer
-        waveform_url:
-          description: Waveform URL.
-          type: string
         available_country_codes:
           description: List of countries where track is available.
           type: string
@@ -233,81 +144,6 @@ components:
         kind:
           description: Type of Soundcloud object (playlist).
           type: string
-        artwork_url:
-          description: URL to a JPEG image.
-          type: string
-        created_at:
-          description: Created timestamp.
-          type: string
-        description:
-          description: Playlist description.
-          type: string
-        downloadable:
-          description: is downloadable.
-          type: boolean
-        duration:
-          description: Playlist duration.
-          type: integer
-        ean:
-          description: European Article Number.
-          type: string
-        embeddable_by:
-          description: Embeddable by.
-          type: string
-        genre:
-          description: Playlist genre.
-          type: string
-        label_id:
-          description: Label user identifier.
-          type: integer
-        label_name:
-          description: Label name.
-          type: string
-        last_modified:
-          description: Last modified timestamp.
-          type: string
-        license:
-          description: License.
-          type: string
-        permalink:
-          description: Playlist permalink.
-          type: string
-        permalink_url:
-          description: Playlist permalink URL.
-          type: string
-        playlist_type:
-          description: Type of playlist.
-          type: string
-        purchase_title:
-          description: Purchase title.
-          type: string
-        purchase_url:
-          description: Purchase URL.
-          type: string
-        release:
-          description: Release.
-          type: string
-        release_day:
-          description: Day of release.
-          type: integer
-        release_month:
-          description: Month of release.
-          type: integer
-        release_year:
-          description: Year of release.
-          type: integer
-        sharing:
-          description: Type of sharing (private/public).
-          type: string
-        streamable:
-          description: Is streamable.
-          type: boolean
-        tag_list:
-          description: Tags.
-          type: string
-        track_count:
-          description: Count of tracks.
-          type: integer
         tracks:
           description: List of tracks.
           type: array
@@ -319,7 +155,6 @@ components:
         uri:
           description: Playlist URI.
           type: string
-        # Problems with User ref 3/8/2024.
         user:
           $ref: '#/components/schemas/User'
         user_id:
@@ -328,8 +163,8 @@ components:
         likes_count:
           description: Count of playlist likes.
           type: integer
-        # label:
-        #   $ref: '#/components/schemas/User'
+        label:
+          $ref: '#/components/schemas/User'
         tracks_uri:
           description: tracks URI.
           type: string

--- a/tests/fixtures/anyOf-simple.yml
+++ b/tests/fixtures/anyOf-simple.yml
@@ -1,0 +1,362 @@
+openapi: 3.0.1
+info:
+  title: Panettone allOf schema
+  version: 1.0.1
+  description: |
+    Simple use case for the `anyOf` schema type.
+
+servers:
+  - url: https://localhost
+paths:
+  /me:
+    get:
+      summary: Returns the authenticated user’s information.
+      responses:
+        '200':
+          $ref: '#/components/responses/Me'
+
+components:
+
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+        link:
+          type: string
+        error:
+          type: string
+          deprecated: true
+        status:
+          type: string
+          deprecated: true
+    TooManyRequests:
+      allOf:
+        - $ref: '#/components/schemas/Error'
+        - type: object
+          properties:
+            spam_warning_urn:
+              type: string
+    Me:
+      type: object
+      description: SoundCloud Me object
+      properties:
+        avatar_url:
+          description: URL to a JPEG image.
+          type: string
+        city:
+          description: city.
+          type: string
+        comments_count:
+          description: comments count. From now on, the field always has a `0` value.
+          type: integer
+          deprecated: true
+
+    Activities:
+      type: object
+      description: User's activities.
+      properties:
+        collection:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                description: Type of activity (track).
+                type: string
+              created_at:
+                description: Created timestamp.
+                type: string
+              origin:
+                description: Origin.
+                type: object
+                anyOf:
+                  - $ref: '#/components/schemas/Track'
+                  - $ref: '#/components/schemas/Playlist'
+        next_href:
+          type: string
+        future_href:
+          type: string
+
+    Track:
+      type: object
+      description: Soundcloud Track object.
+      properties:
+        title:
+          description: Track title.
+          type: string
+        artwork_url:
+          description: URL to a JPEG image.
+          type: string
+        bpm:
+          description: Tempo.
+          type: integer
+        comment_count:
+          description: Number of comments.
+          type: integer
+        commentable:
+          description: Is commentable.
+          type: boolean
+        created_at:
+          description: Created timestamp.
+          type: string
+        description:
+          description: Track description.
+          type: string
+        download_count:
+          description: NUmber of downloads.
+          type: integer
+        downloadable:
+          description: Is downloadable.
+          type: string
+        duration:
+          description: Track duration.
+          type: integer
+        embeddable_by:
+          deprecated: true
+          description: Embeddable by.
+          type: string
+        favoritings_count:
+          description: Number of favoritings.
+          type: integer
+        genre:
+          description: Genre
+          type: string
+        id:
+          description: Track identifier.
+          type: integer
+        isrc:
+          description: ISRC code.
+          type: string
+        key_signature:
+          description: Key signature.
+          type: string
+        kind:
+          description: Type of object (track).
+          type: string
+        label_name:
+          description: Label user name.
+          type: string
+        license:
+          description: License
+          type: string
+        permalink_url:
+          description: Permalink URL.
+          type: string
+        playback_count:
+          description: Number of plays.
+          type: integer
+        purchase_title:
+          description: Purchase title.
+          type: string
+        purchase_url:
+          description: Purchase URL.
+          type: string
+        release:
+          description: Release.
+          type: string
+        release_day:
+          description: Day of release.
+          type: integer
+        release_month:
+          description: Month of release.
+          type: integer
+        release_year:
+          description: Year of release.
+          type: integer
+        sharing:
+          description: Type of sharing (public/private).
+          type: string
+        stream_url:
+          description: URL to stream.
+          type: string
+        streamable:
+          description: Is streamable.
+          type: boolean
+        tag_list:
+          description: Tags.
+          type: string
+        uri:
+          description: Track URI.
+          type: string
+        # Having trouble with references in Panettone 3/8/2024.
+        # user:
+        #   $ref: '#/components/schemas/User'
+        user_favorite:
+          description: Is user's favourite.
+          type: boolean
+        user_playback_count:
+          description: Number of plays by a user.
+          type: integer
+        waveform_url:
+          description: Waveform URL.
+          type: string
+        available_country_codes:
+          description: List of countries where track is available.
+          type: string
+        access:
+          type: string
+          nullable: true
+          description: |
+            Level of access the user (logged in or anonymous) has to the track.
+              * `playable` - user is allowed to listen to a full track.
+              * `preview` - user is allowed to preview a track, meaning a snippet is available
+              * `blocked` - user can only see the metadata of a track, no streaming is possible
+          enum:
+            - playable
+            - preview
+            - blocked
+            - null
+        download_url:
+          description: URL to download a track.
+          type: string
+        reposts_count:
+          description: Number of reposts.
+          type: integer
+        secret_uri:
+          description: Secret URL.
+          type: string
+
+    Playlist:
+      type: object
+      description: Soundcloud Playlist Object
+      properties:
+        title:
+          description: Playlist title.
+          type: string
+        id:
+          description: Playlist identifier.
+          type: integer
+        kind:
+          description: Type of Soundcloud object (playlist).
+          type: string
+        artwork_url:
+          description: URL to a JPEG image.
+          type: string
+        created_at:
+          description: Created timestamp.
+          type: string
+        description:
+          description: Playlist description.
+          type: string
+        downloadable:
+          description: is downloadable.
+          type: boolean
+        duration:
+          description: Playlist duration.
+          type: integer
+        ean:
+          description: European Article Number.
+          type: string
+        embeddable_by:
+          description: Embeddable by.
+          type: string
+        genre:
+          description: Playlist genre.
+          type: string
+        label_id:
+          description: Label user identifier.
+          type: integer
+        label_name:
+          description: Label name.
+          type: string
+        last_modified:
+          description: Last modified timestamp.
+          type: string
+        license:
+          description: License.
+          type: string
+        permalink:
+          description: Playlist permalink.
+          type: string
+        permalink_url:
+          description: Playlist permalink URL.
+          type: string
+        playlist_type:
+          description: Type of playlist.
+          type: string
+        purchase_title:
+          description: Purchase title.
+          type: string
+        purchase_url:
+          description: Purchase URL.
+          type: string
+        release:
+          description: Release.
+          type: string
+        release_day:
+          description: Day of release.
+          type: integer
+        release_month:
+          description: Month of release.
+          type: integer
+        release_year:
+          description: Year of release.
+          type: integer
+        sharing:
+          description: Type of sharing (private/public).
+          type: string
+        streamable:
+          description: Is streamable.
+          type: boolean
+        tag_list:
+          description: Tags.
+          type: string
+        track_count:
+          description: Count of tracks.
+          type: integer
+        tracks:
+          description: List of tracks.
+          type: array
+          items:
+            $ref: '#/components/schemas/Track'
+        type:
+          description: Playlist type.
+          type: string
+        uri:
+          description: Playlist URI.
+          type: string
+        # Problems with User ref 3/8/2024.
+        user:
+          $ref: '#/components/schemas/User'
+        user_id:
+          description: User identifier.
+          type: integer
+        likes_count:
+          description: Count of playlist likes.
+          type: integer
+        # label:
+        #   $ref: '#/components/schemas/User'
+        tracks_uri:
+          description: tracks URI.
+          type: string
+        tags:
+          description: Tags.
+          type: string
+
+    Playlists:
+      type: object
+      properties:
+        collection:
+          type: array
+          items:
+            $ref: '#/components/schemas/Playlist'
+        next_href:
+          type: string
+
+    PlaylistsArray:
+      deprecated: true
+      type: array
+      items:
+        $ref: '#/components/schemas/Playlist'
+
+  responses:
+    Me:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Me'

--- a/tests/fixtures/anyOf-simple.yml
+++ b/tests/fixtures/anyOf-simple.yml
@@ -353,6 +353,92 @@ components:
       items:
         $ref: '#/components/schemas/Playlist'
 
+    User:
+      type: object
+      description: SoundCloud User object
+      properties:
+        avatar_url:
+          description: URL to a JPEG image
+          type: string
+        city:
+          description: city
+          type: string
+        country:
+          description: country
+          type: string
+        description:
+          description: description
+          type: string
+        discogs_name:
+          description: discogs name
+          type: string
+        first_name:
+          description: first name
+          type: string
+        followers_count:
+          description: number of followers
+          type: integer
+        followings_count:
+          description: number of followed users
+          type: integer
+        full_name:
+          description: first and last name
+          type: string
+        id:
+          description: unique identifier
+          type: integer
+        kind:
+          description: kind of resource
+          type: string
+        created_at:
+          description: profile creation datetime
+          format: date-time
+          type: string
+        last_modified:
+          description: last modified datetime
+          format: date-time
+          type: string
+        last_name:
+          description: last name
+          type: string
+        myspace_name:
+          description: myspace name
+          type: string
+          deprecated: true
+        permalink:
+          description: permalink of the resource
+          type: string
+        permalink_url:
+          description: URL to the SoundCloud.com page
+          type: string
+        plan:
+          description: subscription plan of the user
+          type: string
+        playlist_count:
+          description: number of public playlists
+          type: integer
+        public_favorites_count:
+          description: number of favorited public tracks
+          type: integer
+        reposts_count:
+          description: number of reposts from user
+          type: integer
+        track_count:
+          description: number of public tracks
+          type: integer
+        uri:
+          description: API resource URL
+          type: string
+        username:
+          description: username
+          type: string
+        website:
+          description: a URL to the website
+          type: string
+        website_title:
+          description: a custom title for the website
+          type: string
+
   responses:
     Me:
       description: Success

--- a/tests/fixtures/starOf-simple.yml
+++ b/tests/fixtures/starOf-simple.yml
@@ -3,7 +3,7 @@ info:
   title: Panettone allOf schema
   version: 1.0.1
   description: |
-    Simple use case for the `anyOf` schema type.
+    Simple use cases for the `anyOf` schema type.
 
 servers:
   - url: https://localhost
@@ -40,6 +40,23 @@ components:
           properties:
             spam_warning_urn:
               type: string
+
+    PanettoneAnyOf:
+      anyOf:
+        - $ref: '#/components/schemas/Error'
+        - type: object
+          properties:
+            inline_obj_string_prop:
+              type: string
+
+    PanettoneOneOf:
+      oneOf:
+        - $ref: '#/components/schemas/Error'
+        - type: object
+          properties:
+            inline_obj_string_prop:
+              type: string
+
     Me:
       type: object
       description: SoundCloud Me object
@@ -194,75 +211,6 @@ components:
       properties:
         avatar_url:
           description: URL to a JPEG image
-          type: string
-        city:
-          description: city
-          type: string
-        country:
-          description: country
-          type: string
-        description:
-          description: description
-          type: string
-        discogs_name:
-          description: discogs name
-          type: string
-        first_name:
-          description: first name
-          type: string
-        followers_count:
-          description: number of followers
-          type: integer
-        followings_count:
-          description: number of followed users
-          type: integer
-        full_name:
-          description: first and last name
-          type: string
-        id:
-          description: unique identifier
-          type: integer
-        kind:
-          description: kind of resource
-          type: string
-        created_at:
-          description: profile creation datetime
-          format: date-time
-          type: string
-        last_modified:
-          description: last modified datetime
-          format: date-time
-          type: string
-        last_name:
-          description: last name
-          type: string
-        myspace_name:
-          description: myspace name
-          type: string
-          deprecated: true
-        permalink:
-          description: permalink of the resource
-          type: string
-        permalink_url:
-          description: URL to the SoundCloud.com page
-          type: string
-        plan:
-          description: subscription plan of the user
-          type: string
-        playlist_count:
-          description: number of public playlists
-          type: integer
-        public_favorites_count:
-          description: number of favorited public tracks
-          type: integer
-        reposts_count:
-          description: number of reposts from user
-          type: integer
-        track_count:
-          description: number of public tracks
-          type: integer
-        uri:
-          description: API resource URL
           type: string
         username:
           description: username

--- a/tests/fixtures/starOf-simple.yml
+++ b/tests/fixtures/starOf-simple.yml
@@ -19,24 +19,9 @@ paths:
 components:
 
   schemas:
-    Error:
-      type: object
-      properties:
-        code:
-          type: integer
-        message:
-          type: string
-        link:
-          type: string
-        error:
-          type: string
-          deprecated: true
-        status:
-          type: string
-          deprecated: true
     TooManyRequests:
       allOf:
-        - $ref: '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Me'
         - type: object
           properties:
             spam_warning_urn:

--- a/tests/fixtures/starOf-simple.yml
+++ b/tests/fixtures/starOf-simple.yml
@@ -1,9 +1,10 @@
 openapi: 3.0.1
 info:
-  title: Panettone allOf schema
+  title: Panettone starOf schemas
   version: 1.0.1
   description: |
-    Simple use cases for the `anyOf` schema type.
+    Simple use cases for `oneOf`, `anyOf`, `allOf`, and `not` schema types.
+
 
 servers:
   - url: https://localhost
@@ -43,18 +44,20 @@ components:
 
     PanettoneAnyOf:
       anyOf:
-        - $ref: '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Me'
+        - $ref: '#/components/schemas/Activities'
         - type: object
           properties:
-            inline_obj_string_prop:
+            inline_obj_string_prop_anyOf:
               type: string
 
     PanettoneOneOf:
       oneOf:
-        - $ref: '#/components/schemas/Error'
+        - $ref: '#/components/schemas/Track'
+        - $ref: '#/components/schemas/User'
         - type: object
           properties:
-            inline_obj_string_prop:
+            inline_obj_string_prop_oneOf:
               type: string
 
     Me:


### PR DESCRIPTION
Fixture and test case (passing) in place.
Do not support anyOf on top-level schema components.
Error condition trigger based on location of schema component relative to parent.
Path detection facilitated by cebe JSON methods.
