### PR TITLE
Re-enable logging

### DIFF
--- a/src/Bread/MediaNoche.php
+++ b/src/Bread/MediaNoche.php
@@ -189,7 +189,12 @@ final class MediaNoche
      */
     public function sourceSchema(array $settings, string $source): array
     {
-        [$spec, $printer] = $this->realSetup($source, false);
+        $debug = false;
+        if ($settings['debug'] ??= false) {
+            $debug = true;
+        }
+        [$spec, $printer] = $this->realSetup($source, $debug);
+
         $classes = [];
         foreach ($spec->components->schemas as $name => $schema) {
             $class = self::newNetteClass($schema, $name, $settings);

--- a/src/Bread/MediaNoche.php
+++ b/src/Bread/MediaNoche.php
@@ -239,6 +239,8 @@ final class MediaNoche
     {
         $__props = [];
 
+        self::$staticLogger->debug(sprintf('Processing class %s', $class_name));
+
         $last = static fn (Schema|Reference $p, ?bool $list = false): string =>
             Collection::fromIterable(
                 $list === false ?
@@ -269,7 +271,7 @@ final class MediaNoche
         // Shape: "array schema, items point to single ref"
         if ($schema->type === 'array') {
             // Don't flatten or inline the reference, instead reference the schema as a type.
-            // $this->logger->debug(sprintf('[%s/%s] Add array class property', $class_name, 'items'));
+            self::$staticLogger->debug(sprintf('[%s/%s] Add array class property', $class_name, 'items'));
             $prop = MediaNoche::nativeProp($settings, $schema, 'items', $last($schema), $class_name);
             $__props[] = $prop;
         }
@@ -325,7 +327,7 @@ final class MediaNoche
 
         if ($schema->allOf) {
             foreach ($compositeGenerator($schema->allOf) as $name => $prop) {
-                // $this->logger->debug(sprintf('[%s/%s] Add class property', $class_name, $name));
+                self::$staticLogger->debug(sprintf('[%s/%s] Add class property', $class_name, $name));
                 $__props[$name] = $prop;
             }
         }
@@ -351,7 +353,7 @@ final class MediaNoche
 
             /** @var Property $prop */
             foreach ($compositeGenerator($schema->anyOf) as $name => $prop) {
-                // $this->logger->debug(sprintf('[%s/%s] Add class property', $class_name, $name));
+                self::$staticLogger->debug(sprintf('[%s/%s] Add class property', $class_name, $name));
                 $__props[$name] = $prop;
             }
         }

--- a/src/Bread/PanDeAgua.php
+++ b/src/Bread/PanDeAgua.php
@@ -49,8 +49,6 @@ final class PanDeAgua
         $path = sprintf('%s/%s.php', $output_path, $class->getName());
 
         $content = $printer->printFile($file);
-        // $this->logger->debug($content);
-
         file_put_contents($path, $content);
     }
 

--- a/src/Command/Main.php
+++ b/src/Command/Main.php
@@ -28,7 +28,8 @@ final class Main extends Command
         $this
             ->setHelp('Generates PHP types from a Open API source.')
             ->addArgument('source', InputArgument::REQUIRED, 'Open API YAML source')
-            ->addArgument('config', InputArgument::OPTIONAL, 'Path to .ini configuration file');
+            ->addArgument('config', InputArgument::OPTIONAL, 'Path to .ini configuration file')
+            ->addArgument('debug', InputArgument::OPTIONAL, 'Print verbose output');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AlexanderAllen\Panettone;
 
-use Psr\Log\{LoggerAwareTrait, NullLogger};
+use Psr\Log\{LoggerAwareTrait, LoggerInterface, NullLogger};
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use cebe\openapi\{Reader, ReferenceContext};
@@ -23,6 +23,8 @@ use Nette\PhpGenerator\PsrPrinter as Printer;
 trait Setup
 {
     use LoggerAwareTrait;
+
+    protected static ?LoggerInterface $staticLogger;
 
     /**
      * The real fixture method - setup the spec and logging for every test.
@@ -43,9 +45,15 @@ trait Setup
      */
     public function realSetup(string $spec, bool $log = false): array
     {
-        $this->setLogger($log ?
+        $logger = $log ?
             new ConsoleLogger(new ConsoleOutput(ConsoleOutput::VERBOSITY_DEBUG)) :
-            new NullLogger());
+            new NullLogger();
+
+        // PSR logger.
+        $this->setLogger($logger);
+
+        // Logger instance copy for static methods.
+        self::$staticLogger = $logger;
 
         return [
             Reader::readFromYamlFile(

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -56,4 +56,13 @@ trait Setup
             new Printer()
         ];
     }
+
+    /**
+     * Return the class-string for the protected logger instance.
+     * @return class-string
+     */
+    public function getLoggerClass(): string
+    {
+        return ($this->logger)::class;
+    }
 }

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -45,15 +45,13 @@ trait Setup
      */
     public function realSetup(string $spec, bool $log = false): array
     {
-        $logger = $log ?
+        // Logger instance copy for static methods.
+        self::$staticLogger = $log ?
             new ConsoleLogger(new ConsoleOutput(ConsoleOutput::VERBOSITY_DEBUG)) :
             new NullLogger();
 
-        // PSR logger.
-        $this->setLogger($logger);
-
-        // Logger instance copy for static methods.
-        self::$staticLogger = $logger;
+        // PSR logger access.
+        $this->setLogger(self::$staticLogger);
 
         return [
             Reader::readFromYamlFile(

--- a/test/Unit/MedianocheTest.php
+++ b/test/Unit/MedianocheTest.php
@@ -232,7 +232,17 @@ class MedianocheTest extends TestCase
         $this->assertEquals(
             'Symfony\Component\Console\Logger\ConsoleLogger',
             $instance->getLoggerClass(),
-            'Assert console (debug) logger instance is used'
+            'Assert logging is turned on'
+        );
+
+        $settings = parse_ini_file('test/schema/settings-nullable.ini', true, INI_SCANNER_TYPED);
+        $instance = new MediaNoche();
+        $instance->sourceSchema($settings, 'test/schema/keyword-allOf-simple.yml');
+
+        $this->assertEquals(
+            'Psr\Log\NullLogger',
+            $instance->getLoggerClass(),
+            'Assert logging is turned off'
         );
     }
 

--- a/test/Unit/MedianocheTest.php
+++ b/test/Unit/MedianocheTest.php
@@ -15,6 +15,7 @@ use loophp\collection\Collection;
 use Nette\Utils\Type as UtilsType;
 use AlexanderAllen\Panettone\Setup as ParentSetup;
 use AlexanderAllen\Panettone\Test\Setup;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 
 /**
  * Test suite for nette generators.
@@ -23,7 +24,7 @@ use AlexanderAllen\Panettone\Test\Setup;
  */
 #[CoversClass(MediaNoche::class)]
 #[CoversClass(UnsupportedSchema::class)]
-#[UsesClass(ParentSetup::class)]
+#[CoversClass(ParentSetup::class)]
 #[UsesClass(PanDeAgua::class)]
 #[TestDox('Medianoche')]
 #[Group('nette')]
@@ -206,7 +207,6 @@ class MedianocheTest extends TestCase
         $this->assertTrue($type->isSimple() && $type->isBuiltin(), 'Assert member property type.');
     }
 
-    #[Group('target')]
     #[TestDox('Assert nullable and default settings')]
     public function testNullableDefault(): void
     {
@@ -221,55 +221,70 @@ class MedianocheTest extends TestCase
         }
     }
 
-    /**
-     * What it says on the tin.
-     *
-     * @TODO Test cases for
-     * - $schema->enum: Required by issue #20
-     * - Other use cases listed in issue #21
-     *
-     * @param Schema $schema
-     * @param string $class_name
-     * @return string The type of Schema.
-     */
-    private function typeMatcher2000(Schema $schema, string $class_name): string
+    #[Group('target')]
+    #[TestDox('Test debug setting')]
+    public function testDebugSetting(): void
     {
-        $unhandled_class = static fn ($type, $class_name): \UnhandledMatchError =>
-            new \UnhandledMatchError(
-                sprintf(
-                    'Unhandled type "%s" for schema "%s"',
-                    $type,
-                    $class_name
-                )
-            );
+        $settings = parse_ini_file('test/schema/settings-debug.ini', true, INI_SCANNER_TYPED);
+        $instance = new MediaNoche();
+        $instance->sourceSchema($settings, 'test/schema/keyword-allOf-simple.yml');
 
-        $adv_types = ['allOf', 'anyOf', 'oneOf'];
-        $advanced = static function (Schema $schema) use ($unhandled_class, $class_name, $adv_types): string {
-
-            //  Could you have a schema with multiple of these?
-            $kind = Collection::fromIterable($adv_types)
-                ->reject(static fn ($v) => is_null($schema->{$v}))
-                ->first('');
-            if (empty($kind)) {
-                // Out of schema types to match, time to throw an exception.
-                throw $unhandled_class('unknown', $class_name);
-            }
-            return $kind;
-        };
-
-        $schemaType = (static fn ($schema): string =>
-            match ($schema->type) {
-                /* @see https://swagger.io/specification/#data-types */
-                'string' => 'string',
-                'integer' => 'int',
-                'boolean' => 'bool',
-                'float', 'double' => 'float',
-                'object' => 'object',
-                'array' => 'array',
-                'date', 'dateTime' => \DateTimeInterface::class,
-                default => $advanced($schema),
-            })($schema);
-
-        return $schemaType;
+        $this->assertEquals(
+            'Symfony\Component\Console\Logger\ConsoleLogger',
+            $instance->getLoggerClass(),
+            'Assert console (debug) logger instance is used'
+        );
     }
+
+    // /**
+    //  * What it says on the tin.
+    //  *
+    //  * @TODO Test cases for
+    //  * - $schema->enum: Required by issue #20
+    //  * - Other use cases listed in issue #21
+    //  *
+    //  * @param Schema $schema
+    //  * @param string $class_name
+    //  * @return string The type of Schema.
+    //  */
+    // private function typeMatcher2000(Schema $schema, string $class_name): string
+    // {
+    //     $unhandled_class = static fn ($type, $class_name): \UnhandledMatchError =>
+    //         new \UnhandledMatchError(
+    //             sprintf(
+    //                 'Unhandled type "%s" for schema "%s"',
+    //                 $type,
+    //                 $class_name
+    //             )
+    //         );
+
+    //     $adv_types = ['allOf', 'anyOf', 'oneOf'];
+    //     $advanced = static function (Schema $schema) use ($unhandled_class, $class_name, $adv_types): string {
+
+    //         //  Could you have a schema with multiple of these?
+    //         $kind = Collection::fromIterable($adv_types)
+    //             ->reject(static fn ($v) => is_null($schema->{$v}))
+    //             ->first('');
+    //         if (empty($kind)) {
+    //             // Out of schema types to match, time to throw an exception.
+    //             throw $unhandled_class('unknown', $class_name);
+    //         }
+    //         return $kind;
+    //     };
+
+    //     $schemaType = (static fn ($schema): string =>
+    //         match ($schema->type) {
+    //             /* @see https://swagger.io/specification/#data-types */
+    //             'string' => 'string',
+    //             'integer' => 'int',
+    //             'boolean' => 'bool',
+    //             'float', 'double' => 'float',
+    //             'object' => 'object',
+    //             'array' => 'array',
+    //             'date', 'dateTime' => \DateTimeInterface::class,
+    //             default => $advanced($schema),
+    //         })($schema);
+
+    //     return $schemaType;
+    // }
 }

--- a/test/Unit/MedianocheTest.php
+++ b/test/Unit/MedianocheTest.php
@@ -36,22 +36,12 @@ class MedianocheTest extends TestCase
     #[TestDox('Create nette class object(s)')]
     public function cebeToNetteObject(): void
     {
-        [$spec, $printer] = $this->realSetup('test/schema/medianoche.yml');
-        $settings = PanDeAgua::getSettings("test/schema/settings.ini");
+        $settings = PanDeAgua::getSettings('test/schema/settings.ini');
+        $classes = (new MediaNoche())->sourceSchema($settings, 'test/schema/medianoche.yml');
 
-        $classes = [];
-        $expected_count = count($spec->components->schemas);
-        foreach ($spec->components->schemas as $name => $schema) {
-            $class = MediaNoche::newNetteClass($schema, $name, $settings);
+        foreach ($classes as $class) {
             self::assertInstanceOf(ClassType::class, $class, 'Generator yields ClassType object(s)');
-            $classes[] = $class;
         }
-
-        self::assertCount(
-            $expected_count,
-            $classes,
-            'The given and yielded object amount is an exact match'
-        );
     }
 
     /**

--- a/test/Unit/PanDeAguaTest.php
+++ b/test/Unit/PanDeAguaTest.php
@@ -68,7 +68,7 @@ class PanDeAguaTest extends TestCase
         $output_path = $settings['file']['output_path'];
         $namespace = $settings['file']['namespace'];
 
-        [$spec, $printer] = $this->realSetup('test/schema/keyword-anyOf-simple.yml', true);
+        [$spec, $printer] = $this->realSetup('test/schema/keyword-anyOf-simple.yml', false);
 
         $classes = [];
         foreach ($spec->components->schemas as $name => $schema) {

--- a/test/schema/settings-debug.ini
+++ b/test/schema/settings-debug.ini
@@ -1,0 +1,12 @@
+; General settings that affect program behavior.
+debug = true
+
+; Global settings for Panettone.
+[file]
+output_path = "tmp"
+
+; Namespace for all files.
+namespace = "Panettone"
+
+; Comment to apply to every generated file.
+comment = "Example file comments are configured in settings.ini."


### PR DESCRIPTION
Adds logging facilities to static methods.
Using static copy of protected logger property.
Static property also has protected visibility.
All tests green, logging confirmed in output.