### PR TITLE
Add support for Enums

### DIFF
--- a/src/Bread/MediaNoche.php
+++ b/src/Bread/MediaNoche.php
@@ -245,10 +245,6 @@ final class MediaNoche
     /**
      * Virtual class generator accepts a cebe object and returns a nette object.
      *
-     * Does two things: generate the class, populate it with properties.
-     *
-     * @TODO Issues #22, #23, namespaces and config file.
-     *
      * @param array<string, mixed> $settings
      */
     public static function newNetteClass(Schema $schema, string $class_name, array $settings): ClassType

--- a/src/Bread/MediaNoche.php
+++ b/src/Bread/MediaNoche.php
@@ -225,7 +225,7 @@ final class MediaNoche
      * Interprets a given Open Api schema into Nette class instances.
      *
      * @param array<string, mixed> $settings
-     * @return array<string, ClassLike|ClassType>
+     * @return array<string, ClassType|EnumType>
      */
     public function sourceSchema(array $settings, string $source): array
     {
@@ -245,8 +245,7 @@ final class MediaNoche
         // Process sidecar.
         if (count(self::$sideCar)) {
             foreach (self::$sideCar as $name => $classLike) {
-                // $class = self::newNetteClass($schema, $name, $settings);
-                // $classes[$name] = $classLike;
+                $classes[$name] = $classLike;
                 $this->logger->debug($printer->printClass($classLike));
             }
         }
@@ -308,7 +307,7 @@ final class MediaNoche
          *
          * @param list<Schema|Reference> $array
          *
-         * @return Generator<string, Property|ClassLike, null, void>
+         * @return Generator<string, mixed, null, void>
          */
         $compositeGenerator = function ($array) use ($class_name, $last, $settings): Generator {
             foreach ($array as $key => $property) {
@@ -381,6 +380,6 @@ final class MediaNoche
         return $__props;
     }
 
-    /**  @var array<ClassLike|ClassType|EnumType|InterfaceType|TraitType> */
+    /**  @var array<ClassType|EnumType|InterfaceType|TraitType> */
     private static array $sideCar = [];
 }

--- a/src/Bread/MediaNoche.php
+++ b/src/Bread/MediaNoche.php
@@ -239,6 +239,16 @@ final class MediaNoche
             $classes[$name] = $class;
             $this->logger->debug($printer->printClass($class));
         }
+
+        // Process sidecar.
+        if (count(self::$sideCar)) {
+            foreach (self::$sideCar as $name => $classLike) {
+                // $class = self::newNetteClass($schema, $name, $settings);
+                // $classes[$name] = $classLike;
+                $this->logger->debug($printer->printClass($classLike));
+            }
+        }
+
         return $classes;
     }
 
@@ -393,6 +403,6 @@ final class MediaNoche
         return $__props;
     }
 
-    /**  @var array<ClassLike> */
-    private static array $sideCar;
+    /**  @var array<ClassLike|ClassType|EnumType|InterfaceType|TraitType> */
+    private static array $sideCar = [];
 }

--- a/src/Bread/MediaNoche.php
+++ b/src/Bread/MediaNoche.php
@@ -221,6 +221,12 @@ final class MediaNoche
         return $enum;
     }
 
+    public function __construct()
+    {
+        // Reset static sidecar on instantiation.
+        self::$sideCar = [];
+    }
+
     /**
      * Interprets a given Open Api schema into Nette class instances.
      *
@@ -273,6 +279,8 @@ final class MediaNoche
     /**
      * Converts all the properties from a cebe Schema into nette Properties.
      *
+     * Modifies `self::sideCart` as a side-effect.
+     *
      * @param Schema $schema
      * @param string $class_name
      * @param array<string, Property> $settings
@@ -298,7 +306,7 @@ final class MediaNoche
         if ($schema->type === 'array') {
             // Don't flatten or inline the reference, instead reference the schema as a type.
             self::$staticLogger->debug(sprintf('[%s/%s] Add array class property', $class_name, 'items'));
-            $prop = MediaNoche::nativeProp($settings, $schema, 'items', $last($schema), $class_name);
+            $prop = self::nativeProp($settings, $schema, 'items', $last($schema), $class_name);
             $__props[] = $prop;
         }
 
@@ -319,7 +327,7 @@ final class MediaNoche
 
                 // Pointer path with string ending is a reference to another schema.
                 if (! is_numeric($lastRef)) {
-                    yield $lastRef => MediaNoche::nativeProp($settings, $property, strtolower($lastRef), $lastRef, $class_name);
+                    yield $lastRef => self::nativeProp($settings, $property, strtolower($lastRef), $lastRef, $class_name);
                 }
 
                 // Pointer path with numerical ending is an internal property.
@@ -332,7 +340,7 @@ final class MediaNoche
                     // The generator steps through all the object properties, causing them to become "inline", or part
                     // of the generated type.
                     foreach ($property->properties as $key => $value) {
-                        yield $key => MediaNoche::nativeProp($settings, $value, $key);
+                        yield $key => self::nativeProp($settings, $value, $key);
                     }
                 }
             }

--- a/src/Bread/MediaNoche.php
+++ b/src/Bread/MediaNoche.php
@@ -15,6 +15,7 @@ use loophp\collection\Collection;
 use Nette\InvalidArgumentException;
 use UnhandledMatchError;
 use Generator;
+use Nette\PhpGenerator\EnumType;
 
 use function Symfony\Component\String\u;
 
@@ -90,6 +91,9 @@ final class MediaNoche
                     // Enum properties are simple, non-composite types that reference other objects.
                     // The type name is capitalized because it references an object.
                     $newProp->setType(ucfirst($_name));
+
+                    // for testing
+                    $foo = self::newNetteEnum($_name, $property->enum);
                 } elseif ($starType == 'allOf') {
                     $newProp->setType(Type::intersection(...$starRefs));
                 } else {
@@ -190,6 +194,31 @@ final class MediaNoche
         }
 
         return $lastRefs;
+    }
+
+    /**
+     * Creates a new Nette enumeration object.
+     *
+     * Use PascalCase per the latest PER-CS recommendations.
+     * @see https://www.php-fig.org/per/coding-style/#9-enumerations
+     *
+     * I do not have an answer for null value enums, therefore supressing null cases.
+     * @see https://github.com/AlexanderAllen/panettone/issues/20
+     *
+     * @param string $name
+     * @param array<string> $cases
+     * @return EnumType
+     */
+    private static function newNetteEnum(string $name, array $cases): EnumType
+    {
+        $pascalCase = fn ($_name) => ucfirst(u($_name)->camel()->toString());
+        $enum = new EnumType($pascalCase($name));
+        foreach ($cases as $case) {
+            if ($case !== null) {
+                $enum->addCase($pascalCase($case));
+            }
+        }
+        return $enum;
     }
 
     /**
@@ -361,3 +390,15 @@ final class MediaNoche
         return $__props;
     }
 }
+
+
+
+
+
+
+// enum TestNull: ?int
+// {
+//     case One = 1;
+//     case Two = 2;
+//     case null = null;
+// }

--- a/src/Bread/PanDeAgua.php
+++ b/src/Bread/PanDeAgua.php
@@ -7,6 +7,7 @@ namespace AlexanderAllen\Panettone\Bread;
 use Nette\InvalidArgumentException;
 use Nette\InvalidStateException;
 use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\EnumType;
 use Nette\PhpGenerator\Printer;
 use Nette\PhpGenerator\PhpFile;
 use Nette\PhpGenerator\PhpNamespace;
@@ -23,19 +24,19 @@ final class PanDeAgua
     /**
      *
      * @param Printer $printer
-     * @param ClassType $class
+     * @param EnumType|ClassType $classLike
      * @param array<string, mixed> $settings
      * @throws InvalidArgumentException
      * @throws InvalidStateException
      */
-    public static function printFile(Printer $printer, ClassType $class, array $settings): void
+    public static function printFile(Printer $printer, ClassType|EnumType $classLike, array $settings): void
     {
         $output_path = $settings['file']['output_path'];
         $namespace = $settings['file']['namespace'];
         $comment = $settings['file']['comment'];
 
         $namespace = new PhpNamespace($namespace);
-        $namespace->add($class);
+        $namespace->add($classLike);
 
         $file = new PhpFile();
         $file->setStrictTypes();
@@ -46,7 +47,7 @@ final class PanDeAgua
         // @see https://doc.nette.org/en/php-generator#toc-class-names-resolving
         $printer->setTypeResolving(false);
 
-        $path = sprintf('%s/%s.php', $output_path, $class->getName());
+        $path = sprintf('%s/%s.php', $output_path, $classLike->getName());
 
         $content = $printer->printFile($file);
         file_put_contents($path, $content);

--- a/test/Unit/MedianocheTest.php
+++ b/test/Unit/MedianocheTest.php
@@ -215,6 +215,33 @@ class MedianocheTest extends TestCase
         $this->assertTrue($type->isSimple() && $type->isBuiltin(), 'Assert member property type.');
     }
 
+    #[Test]
+    #[Group('target')]
+    #[TestDox('Assert use case for enumerations')]
+    public function schemaEnum(): void
+    {
+        $settings = PanDeAgua::getSettings('test/schema/settings.ini');
+        $classes = (new MediaNoche())->sourceSchema($settings, 'test/schema/keyword-enum-simple.yml');
+
+        $this->assertArrayHasKey('PanettoneEnum', $classes, 'Test subject is present');
+        $subject = $classes['PanettoneEnum'];
+        $this->assertTrue($subject->hasProperty('enumPastries'), 'Test property is present');
+        $member = $subject->getProperty('enumPastries');
+
+        $type = UtilsType::fromString($member->getType());
+
+        $this->assertEquals(
+            'enumPastries',
+            $type->getSingleName(),
+            'Assert member property references another object type.'
+        );
+
+        // $this->assertTrue($type->isSimple() && $type->isBuiltin(), 'Assert member property type.');
+
+
+        $test = null;
+    }
+
     #[TestDox('Assert nullable and default settings')]
     public function testNullableDefault(): void
     {

--- a/test/Unit/MedianocheTest.php
+++ b/test/Unit/MedianocheTest.php
@@ -215,12 +215,19 @@ class MedianocheTest extends TestCase
         $this->assertTrue($type->isSimple() && $type->isBuiltin(), 'Assert member property type.');
     }
 
+    /**
+     * Test case for enumerated properties.
+     *
+     * If an enum has been detected, the property will reference an Enum object,
+     * and therefore should follow object naming conventions. Both property and type
+     * names are camel case, but the type is capitalized and the prop name is not.
+     */
     #[Test]
     #[Group('target')]
     #[TestDox('Assert use case for enumerations')]
     public function schemaEnum(): void
     {
-        $settings = PanDeAgua::getSettings('test/schema/settings.ini');
+        $settings = PanDeAgua::getSettings('test/schema/settings-debug.ini');
         $classes = (new MediaNoche())->sourceSchema($settings, 'test/schema/keyword-enum-simple.yml');
 
         $this->assertArrayHasKey('PanettoneEnum', $classes, 'Test subject is present');
@@ -231,7 +238,7 @@ class MedianocheTest extends TestCase
         $type = UtilsType::fromString($member->getType());
 
         $this->assertEquals(
-            'enumPastries',
+            'EnumPastries',
             $type->getSingleName(),
             'Assert member property references another object type.'
         );

--- a/test/Unit/MedianocheTest.php
+++ b/test/Unit/MedianocheTest.php
@@ -250,11 +250,6 @@ class MedianocheTest extends TestCase
             $type->getSingleName(),
             'Assert member property references another object type.'
         );
-
-        // $this->assertTrue($type->isSimple() && $type->isBuiltin(), 'Assert member property type.');
-
-
-        $test = null;
     }
 
     #[TestDox('Assert nullable and default settings')]
@@ -264,9 +259,11 @@ class MedianocheTest extends TestCase
         $classes = (new MediaNoche())->sourceSchema($settings, 'test/schema/keyword-allOf-simple.yml');
 
         foreach ($classes as $class) {
-            foreach ($class->getProperties() as $prop) {
-                $this->assertTrue($prop->isInitialized(), 'Property has default value assinged');
-                $this->assertTrue($prop->isNullable(), 'Property is set as nullable');
+            if ($class instanceof ClassType) {
+                foreach ($class->getProperties() as $prop) {
+                    $this->assertTrue($prop->isInitialized(), 'Property has default value assinged');
+                    $this->assertTrue($prop->isNullable(), 'Property is set as nullable');
+                }
             }
         }
     }

--- a/test/Unit/MedianocheTest.php
+++ b/test/Unit/MedianocheTest.php
@@ -13,6 +13,7 @@ use Nette\PhpGenerator\ClassType;
 use Nette\Utils\Type as UtilsType;
 use AlexanderAllen\Panettone\Setup as ParentSetup;
 use AlexanderAllen\Panettone\Test\Setup;
+use Nette\PhpGenerator\EnumType;
 
 /**
  * Test suite for nette generators.
@@ -30,14 +31,21 @@ class MedianocheTest extends TestCase
     use Setup;
 
     #[Test]
-    #[TestDox('Create nette class object(s)')]
+    #[TestDox('Emit Nette "class like" object(s)')]
     public function cebeToNetteObject(): void
     {
         $settings = PanDeAgua::getSettings('test/schema/settings.ini');
         $classes = (new MediaNoche())->sourceSchema($settings, 'test/schema/medianoche.yml');
 
+        $allowed = [
+            ClassType::class,
+            EnumType::class,
+        ];
         foreach ($classes as $class) {
-            self::assertInstanceOf(ClassType::class, $class, 'Generator yields ClassType object(s)');
+            $this->assertNotFalse(
+                array_search($class::class, $allowed, true),
+                'Medianoche emits instances of the correct Nette objects'
+            );
         }
     }
 

--- a/test/Unit/PampushkaTest.php
+++ b/test/Unit/PampushkaTest.php
@@ -39,7 +39,7 @@ class PampushkaTest extends TestCase
     public function testCommand(): void
     {
         // Statically cache a valid settings location for the command.
-        PanDeAgua::getSettings("test/schema/settings.ini");
+        PanDeAgua::getSettings('test/schema/settings-debug.ini');
 
         $app = new Application('panettone', '0.0.0');
         $app->setAutoExit(false);

--- a/test/Unit/PampushkaTest.php
+++ b/test/Unit/PampushkaTest.php
@@ -46,7 +46,7 @@ class PampushkaTest extends TestCase
         $main = new Main();
         $app->add($main);
         $app->setDefaultCommand($main->getName(), true);
-        $input = ['input' => 'test/schema/keyword-anyOf-simple.yml'];
+        $input = ['input' => 'test/schema/keyword-enum-simple.yml'];
 
         $appTester = new ApplicationTester($app);
         $this->assertEquals(Command::SUCCESS, $appTester->run($input, []));
@@ -78,7 +78,7 @@ class PampushkaTest extends TestCase
         $main = new Main();
         $app->add($main);
         $app->setDefaultCommand($main->getName(), true);
-        $input = ['input' => 'test/schema/keyword-anyOf-simple.yml'];
+        $input = ['input' => 'test/schema/keyword-enum-simple.yml'];
 
         // For options available see initOutput() in TesterTrait.php.
         // Panettone recognizes only one verbosity setting, so anything above
@@ -117,7 +117,7 @@ class PampushkaTest extends TestCase
         $app->add($main);
         $app->setDefaultCommand($main->getName(), true);
         $input = [];
-        $input['input'] = 'test/schema/keyword-anyOf-simple.yml';
+        $input['input'] = 'test/schema/keyword-enum-simple.yml';
         $input['output'] = 'tmp';
 
         $appTester = new ApplicationTester($app);

--- a/test/Unit/PanDeAguaTest.php
+++ b/test/Unit/PanDeAguaTest.php
@@ -28,7 +28,7 @@ class PanDeAguaTest extends TestCase
 {
     use Setup;
 
-    // #[Group('target')]
+    #[Group('target')]
     #[TestDox('File printer test')]
     public function testFilePrinter(): void
     {

--- a/test/schema/keyword-enum-simple.yml
+++ b/test/schema/keyword-enum-simple.yml
@@ -31,6 +31,10 @@ components:
     PanettoneEnum:
       type: object
       properties:
+        # enums cases are super interesting in that they are both a property
+        # of their parent object, but they can also be interpreted as a
+        # object by themselves. However unlike object references, enums lack
+        # their own components/schemas entry.
         enum_pastries:
           description: |
             Delicious Puerto Rican pastries.

--- a/test/schema/keyword-enum-simple.yml
+++ b/test/schema/keyword-enum-simple.yml
@@ -1,0 +1,117 @@
+openapi: 3.0.1
+info:
+  title: Panettone enum schema
+  version: 1.0.1
+  description: |
+    Simple use cases for `enum` type.
+
+
+servers:
+  - url: https://localhost
+paths:
+  /me:
+    get:
+      summary: Boilerplate example response.
+      responses:
+        '200':
+          $ref: '#/components/responses/Panettone'
+
+components:
+
+  responses:
+    Panettone:
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PanettoneEnum'
+
+  schemas:
+
+    PanettoneEnum:
+      type: object
+      properties:
+        enum_pastries:
+          description: |
+            Delicious Puerto Rican pastries.
+            One of `quesito`, `pastelillo`, or `besitos de coco`.
+          type: string
+          example: pastelillo
+          enum:
+            - quesito
+            - pastelillo
+            - besitos de coco
+        type:
+          description: Type of activity (track).
+          type: string
+          nullable: true
+          readOnly: true
+        created_at:
+          description: Created timestamp.
+          type: string
+        origin:
+          description: Origin.
+          type: object
+          anyOf:
+            - $ref: '#/components/schemas/Me'
+            - $ref: '#/components/schemas/User'
+          nullable: true
+          readOnly: true
+
+    Me:
+      type: object
+      description: SoundCloud Me object
+      properties:
+        avatar_url:
+          description: URL to a JPEG image.
+          type: string
+        city:
+          description: city.
+          type: string
+        comments_count:
+          description: comments count. From now on, the field always has a `0` value.
+          type: integer
+          deprecated: true
+
+    Activities:
+      type: object
+      description: User's activities.
+      properties:
+        collection:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                description: Type of activity (track).
+                type: string
+              created_at:
+                description: Created timestamp.
+                type: string
+              origin:
+                description: Origin.
+                type: object
+                anyOf:
+                  - $ref: '#/components/schemas/Me'
+                  - $ref: '#/components/schemas/User'
+        next_href:
+          type: string
+        future_href:
+          type: string
+
+    User:
+      type: object
+      description: SoundCloud User object
+      properties:
+        avatar_url:
+          description: URL to a JPEG image
+          type: string
+        username:
+          description: username
+          type: string
+        website:
+          description: a URL to the website
+          type: string
+        website_title:
+          description: a custom title for the website
+          type: string

--- a/test/schema/keyword-enum-simple.yml
+++ b/test/schema/keyword-enum-simple.yml
@@ -37,10 +37,12 @@ components:
             One of `quesito`, `pastelillo`, or `besitos de coco`.
           type: string
           example: pastelillo
+          nullable: true
           enum:
             - quesito
             - pastelillo
             - besitos de coco
+            - null
         type:
           description: Type of activity (track).
           type: string

--- a/test/schema/medianoche-1.yml
+++ b/test/schema/medianoche-1.yml
@@ -118,19 +118,22 @@ components:
         available_country_codes:
           description: List of countries where track is available.
           type: string
-        access:
-          type: string
-          nullable: true
-          description: |
-            Level of access the user (logged in or anonymous) has to the track.
-              * `playable` - user is allowed to listen to a full track.
-              * `preview` - user is allowed to preview a track, meaning a snippet is available
-              * `blocked` - user can only see the metadata of a track, no streaming is possible
-          enum:
-            - playable
-            - preview
-            - blocked
-            - null
+        # The unit tests using this schema should not be testing for enums,
+        # there's are separate unit tests for enums.
+        #
+        # access:
+        #   type: string
+        #   nullable: true
+        #   description: |
+        #     Level of access the user (logged in or anonymous) has to the track.
+        #       * `playable` - user is allowed to listen to a full track.
+        #       * `preview` - user is allowed to preview a track, meaning a snippet is available
+        #       * `blocked` - user can only see the metadata of a track, no streaming is possible
+        #   enum:
+        #     - playable
+        #     - preview
+        #     - blocked
+        #     - null
         download_url:
           description: URL to download a track.
           type: string

--- a/tools/phpcs/phpcs.xml
+++ b/tools/phpcs/phpcs.xml
@@ -13,7 +13,10 @@
   <!-- See https://github.com/slevomat/coding-standard -->
   <config name="installed_paths" value="tools/phpcs/vendor/slevomat/coding-standard"/>
 
-  <rule ref="PSR12" />
+  <rule ref="PSR12">
+    <!-- Allow embedded enums in class files -->
+    <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
+  </rule>
 
   <rule ref="Generic.Metrics.CyclomaticComplexity">
       <properties>


### PR DESCRIPTION
This PR finally adds support for interpreting `enum` in OAS sources and emitting enum type files.

Took about 2-3 days to implement, with a little less effort/changes that I expected.
However, some internal side effects are introduced.
Because these side effects do not adversely impact test coverage, I am merging.
Because the side effects do not align my design goal of writing code in a functional matter (or at least as much as I can), I have created #43.

Why not do both at once? Because I do not want to let the perfect get in the way of the perfectly functional. 

#43 might be a biggie, merging this PR is also nice way of breaking up the workload.

Screenshot of emitted enum below:

![image](https://github.com/AlexanderAllen/panettone/assets/14018885/d65a001f-e642-4064-bfa4-88b77512c34c)
