### PR TITLE
Make MediaNoche Stateless Again

### DIFF
--- a/test/Unit/MedianocheTest.php
+++ b/test/Unit/MedianocheTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlexanderAllen\Panettone\Test\Unit;
 
 use AlexanderAllen\Panettone\Bread\MediaNoche;
+use AlexanderAllen\Panettone\Bread\NetteContainer;
 use AlexanderAllen\Panettone\Bread\PanDeAgua;
 use AlexanderAllen\Panettone\UnsupportedSchema;
 use PHPUnit\Framework\TestCase;
@@ -14,6 +15,7 @@ use Nette\Utils\Type as UtilsType;
 use AlexanderAllen\Panettone\Setup as ParentSetup;
 use AlexanderAllen\Panettone\Test\Setup;
 use Nette\PhpGenerator\EnumType;
+use Nette\PhpGenerator\Property;
 
 /**
  * Test suite for nette generators.
@@ -23,6 +25,7 @@ use Nette\PhpGenerator\EnumType;
 #[CoversClass(MediaNoche::class)]
 #[CoversClass(UnsupportedSchema::class)]
 #[CoversClass(ParentSetup::class)]
+#[CoversClass(NetteContainer::class)]
 #[UsesClass(PanDeAgua::class)]
 #[TestDox('Medianoche: Fwuffy Cuban sandwich bread')]
 #[Group('nette')]
@@ -59,26 +62,16 @@ class MedianocheTest extends TestCase
         [$spec, $printer] = $this->realSetup('test/schema/medianoche-1.yml');
         $settings = PanDeAgua::getSettings("test/schema/settings.ini");
 
-        $classes = [];
-        $expected_count = count($spec->components->schemas);
         foreach ($spec->components->schemas as $name => $schema) {
-            $class = MediaNoche::newNetteClass($schema, $name, $settings);
-            self::assertInstanceOf(ClassType::class, $class, 'Generator yields ClassType object(s)');
-            $classes[] = $class;
-            $this->logger->debug($printer->printClass($class));
+            $container = MediaNoche::newNetteClass($schema, $name, $settings);
+            $this->assertInstanceOf(NetteContainer::class, $container);
+            $this->assertContainsOnlyInstancesOf(Property::class, $container->props);
+            $this->assertInstanceOf(ClassType::class, $container->class, 'Generator yields ClassType object(s)');
         }
-
-        self::assertCount(
-            $expected_count,
-            $classes,
-            'The given and yielded object amount is an exact match'
-        );
     }
 
     /**
      * Test case for allOf.
-     *
-     * @TODO Update assertions, see issue #19.
      */
     #[Test]
     #[Depends('proceduralish')]

--- a/test/Unit/PampushkaTest.php
+++ b/test/Unit/PampushkaTest.php
@@ -8,6 +8,7 @@ use AlexanderAllen\Panettone\Test\Setup;
 use AlexanderAllen\Panettone\Setup as ParentSetup;
 use AlexanderAllen\Panettone\Bread\PanDeAgua;
 use AlexanderAllen\Panettone\Bread\MediaNoche;
+use AlexanderAllen\Panettone\Bread\NetteContainer;
 use AlexanderAllen\Panettone\Command\Main;
 use PHPUnit\Framework\Attributes\{CoversClass, Group, TestDox, UsesClass};
 use PHPUnit\Framework\TestCase;
@@ -29,6 +30,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[CoversClass(PanDeAgua::class)]
 #[UsesClass(MediaNoche::class)]
 #[UsesClass(ParentSetup::class)]
+#[UsesClass(NetteContainer::class)]
 #[CoversClass(Main::class)]
 #[TestDox('Pampushka: Ukranian garlic bread')]
 class PampushkaTest extends TestCase

--- a/test/Unit/PanDeAguaTest.php
+++ b/test/Unit/PanDeAguaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlexanderAllen\Panettone\Test\Unit;
 
 use AlexanderAllen\Panettone\Bread\MediaNoche;
+use AlexanderAllen\Panettone\Bread\NetteContainer;
 use AlexanderAllen\Panettone\Bread\PanDeAgua;
 use PHPUnit\Framework\Attributes\{CoversClass, Group, TestDox, UsesClass};
 use Nette\PhpGenerator\PhpFile;
@@ -23,6 +24,7 @@ use AlexanderAllen\Panettone\Test\Setup;
 #[CoversClass(PanDeAgua::class)]
 #[UsesClass(MediaNoche::class)]
 #[UsesClass(ParentSetup::class)]
+#[UsesClass(NetteContainer::class)]
 #[TestDox('Pan de agua: Crusty Puerto Rican water bread')]
 class PanDeAguaTest extends TestCase
 {
@@ -37,10 +39,10 @@ class PanDeAguaTest extends TestCase
 
         $classes = [];
         foreach ($spec->components->schemas as $name => $schema) {
-            $class = MediaNoche::newNetteClass($schema, $name, $settings);
-            $classes[$name] = $class;
+            $container = MediaNoche::newNetteClass($schema, $name, $settings);
+            $classes[$name] = $container->class;
 
-            $this->logger->debug($printer->printClass($class));
+            $this->logger->debug($printer->printClass($container->class));
         }
 
         foreach ($classes as $name => $class_type) {
@@ -72,9 +74,8 @@ class PanDeAguaTest extends TestCase
 
         $classes = [];
         foreach ($spec->components->schemas as $name => $schema) {
-            $class = MediaNoche::newNetteClass($schema, $name, $settings);
-            $classes[$name] = $class;
-            // $this->logger->debug($printer->printClass($class));
+            $container = MediaNoche::newNetteClass($schema, $name, $settings);
+            $classes[$name] = $container->class;
         }
 
         foreach ($classes as $name => $class_type) {


### PR DESCRIPTION
I swear I didn't conspire to make the PR title and number match!
What an RNGesus draw (facepalm)

This _biggie_ ended up talking all of one hour and a half?
It's all internal, mostly:

- [`sourceSchema`](https://github.com/AlexanderAllen/panettone/blob/3e8feb8e4575a5461dbd6783d10aab24e387304b/src/Bread/MediaNoche.php#L231) still returns an old-school array and not a typed data container. This kept the amount of changes required to tests down.
- [`newNetteClass`](https://github.com/AlexanderAllen/panettone/blob/3e8feb8e4575a5461dbd6783d10aab24e387304b/src/Bread/MediaNoche.php#L262) and `sourceSchema` do make use of the new [`NetteContainer`](https://github.com/AlexanderAllen/panettone/blob/3e8feb8e4575a5461dbd6783d10aab24e387304b/src/Bread/MediaNoche.php#L392) to avoid storing state inside MediaNoche.
- Bunch of tests got updated, but changes were fairly minimal.

Oh, and I do want my _functional_ points: the data container [`NetteContainer`](https://github.com/AlexanderAllen/panettone/blob/3e8feb8e4575a5461dbd6783d10aab24e387304b/src/Bread/MediaNoche.php#L392) _is_ read-only :)

Coverage being reported locally is 100% 🎉

