### PR TITLE
Back enums with literal value sourced from OAS.

### DIFF
--- a/src/Bread/MediaNoche.php
+++ b/src/Bread/MediaNoche.php
@@ -216,7 +216,7 @@ final class MediaNoche
         $enum = new EnumType($pascalCase($name));
         foreach ($cases as $case) {
             if ($case != null) {
-                $enum->addCase($pascalCase($case));
+                $enum->addCase($pascalCase($case), $case);
             }
         }
         return $enum;


### PR DESCRIPTION
This was a quick one - a one-liner!

- The backed enum should support both `string` and `int`.
- All tests green, no modification done to tests to target specifically string or int, I'm being lazy here.

Comment on #46 demonstrates emitted enum with string backing.